### PR TITLE
- enable support for ssh-agents

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <description>The Git SCM provider for the Unleash Maven Plugin.</description>
   <url>https://github.com/shillner/unleash-scm-provider-git</url>
   <inceptionYear>2016</inceptionYear>
-  
+
   <developers>
     <developer>
       <id>shillner</id>
@@ -31,7 +31,7 @@
     <url>https://github.com/shillner/unleash-scm-provider-git</url>
     <tag>HEAD</tag>
   </scm>
-  
+
   <issueManagement>
     <system>GitHub</system>
     <url>https://github.com/shillner/unleash-scm-provider-git/issues</url>
@@ -40,6 +40,10 @@
   <properties>
     <version.java>1.6</version.java>
     <version.jgit>4.3.0.201604071810-r</version.jgit>
+    <version.jsch-agentproxy>0.0.9</version.jsch-agentproxy>
+    <version.junit>4.12</version.junit>
+    <version.mockito-all>1.10.19</version.mockito-all>
+    <version.slf4j>1.7.2</version.slf4j>
     <version.unleash-scm-provider-api>2.0.0-SNAPSHOT</version.unleash-scm-provider-api>
   </properties>
 
@@ -53,6 +57,39 @@
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>
       <version>${version.jgit}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.jcraft</groupId>
+      <artifactId>jsch.agentproxy.jsch</artifactId>
+      <version>${version.jsch-agentproxy}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.jcraft</groupId>
+      <artifactId>jsch.agentproxy.usocket-jna</artifactId>
+      <version>${version.jsch-agentproxy}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.jcraft</groupId>
+      <artifactId>jsch.agentproxy.sshagent</artifactId>
+      <version>${version.jsch-agentproxy}</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${version.junit}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>${version.mockito-all}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${version.slf4j}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,12 +65,17 @@
     </dependency>
     <dependency>
       <groupId>com.jcraft</groupId>
-      <artifactId>jsch.agentproxy.usocket-jna</artifactId>
+      <artifactId>jsch.agentproxy.pageant</artifactId>
       <version>${version.jsch-agentproxy}</version>
     </dependency>
     <dependency>
       <groupId>com.jcraft</groupId>
       <artifactId>jsch.agentproxy.sshagent</artifactId>
+      <version>${version.jsch-agentproxy}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.jcraft</groupId>
+      <artifactId>jsch.agentproxy.usocket-jna</artifactId>
       <version>${version.jsch-agentproxy}</version>
     </dependency>
     <dependency>

--- a/src/main/java/com/itemis/maven/plugins/unleash/scm/providers/GitSshSessionFactory.java
+++ b/src/main/java/com/itemis/maven/plugins/unleash/scm/providers/GitSshSessionFactory.java
@@ -1,0 +1,84 @@
+package com.itemis.maven.plugins.unleash.scm.providers;
+
+import java.util.logging.Logger;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.itemis.maven.plugins.unleash.scm.ScmProviderInitialization;
+import com.jcraft.jsch.IdentityRepository;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.agentproxy.AgentProxyException;
+import com.jcraft.jsch.agentproxy.Connector;
+import com.jcraft.jsch.agentproxy.RemoteIdentityRepository;
+import com.jcraft.jsch.agentproxy.USocketFactory;
+import com.jcraft.jsch.agentproxy.connector.SSHAgentConnector;
+import com.jcraft.jsch.agentproxy.usocket.JNAUSocketFactory;
+
+import org.eclipse.jgit.transport.JschConfigSessionFactory;
+import org.eclipse.jgit.transport.OpenSshConfig.Host;
+import org.eclipse.jgit.util.FS;
+
+class GitSshSessionFactory extends JschConfigSessionFactory {
+
+    static final String PREFERRED_AUTHENTICATIONS = "PreferredAuthentications";
+    static final String PUBLIC_KEY = "publickey";
+
+    private final ScmProviderInitialization initialization;
+    private final Logger logger;
+
+    GitSshSessionFactory(ScmProviderInitialization initialization, Logger logger) {
+        this.initialization = initialization;
+        this.logger = logger;
+    }
+
+    @Override
+    protected void configure(Host hc, Session session) {
+    }
+
+    @Override
+    protected JSch createDefaultJSch(FS fs) throws JSchException {
+        JSch defaultJSch = super.createDefaultJSch(fs);
+
+        /*
+         * it appears that jsch can only work with a single 'IdentityRepository', so we default to
+         * using the passphrase if it is passed, otherwise we fall back to trying the ssh agent
+         */
+        if (initialization.getSshPrivateKeyPassphrase().isPresent()) {
+            String passphrase = initialization.getSshPrivateKeyPassphrase().get();
+            for (Object itentityName : defaultJSch.getIdentityNames()) {
+                defaultJSch.addIdentity(itentityName.toString(), passphrase);
+            }
+        } else {
+            Connector sshAgentConnector = getAgentConnector();
+            if (sshAgentConnector != null) {
+                JSch.setConfig(PREFERRED_AUTHENTICATIONS, PUBLIC_KEY);
+
+                IdentityRepository identityRepository = new RemoteIdentityRepository(sshAgentConnector);
+                defaultJSch.setIdentityRepository(identityRepository);
+            }
+        }
+
+        return defaultJSch;
+    }
+
+    @VisibleForTesting
+    boolean isConnectorAvailable() {
+        return SSHAgentConnector.isConnectorAvailable();
+    }
+
+    private Connector getAgentConnector() {
+        Connector connector = null;
+
+        try {
+            if (isConnectorAvailable()) {
+                USocketFactory usf = new JNAUSocketFactory();
+                connector = new SSHAgentConnector(usf);
+            }
+        } catch (AgentProxyException e) {
+            logger.warning("failed to create connector to ssh agent: " + e.getMessage());
+        }
+
+        return connector;
+    }
+}

--- a/src/test/java/com/itemis/maven/plugins/unleash/scm/providers/GitSshSessionFactoryTest.java
+++ b/src/test/java/com/itemis/maven/plugins/unleash/scm/providers/GitSshSessionFactoryTest.java
@@ -1,0 +1,119 @@
+package com.itemis.maven.plugins.unleash.scm.providers;
+
+import static com.itemis.maven.plugins.unleash.scm.providers.GitSshSessionFactory.PREFERRED_AUTHENTICATIONS;
+import static com.itemis.maven.plugins.unleash.scm.providers.GitSshSessionFactory.PUBLIC_KEY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.Hashtable;
+import java.util.logging.Logger;
+
+import com.google.common.base.Optional;
+import com.itemis.maven.plugins.unleash.scm.ScmProviderInitialization;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.agentproxy.RemoteIdentityRepository;
+
+import org.eclipse.jgit.util.FS;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class GitSshSessionFactoryTest {
+
+    private boolean connectorAvailable;
+
+    @Mock
+    private FS mockFS;
+
+    @Mock
+    private ScmProviderInitialization mockInitialization;
+
+    @Mock
+    private Logger mockLogger;
+
+    private GitSshSessionFactory sessionFactory;
+
+    private JSch sshClient;
+
+    @Before
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+        // reset this before every tests b/c it's static :(
+        JSch.setConfig(new Hashtable<Object, Object>());
+
+        sessionFactory = new GitSshSessionFactory(mockInitialization, mockLogger) {
+            @Override
+            boolean isConnectorAvailable() {
+                return connectorAvailable;
+            }
+        };
+    }
+
+    @Test
+    public void testNoPassphraseOrAgent() throws Exception {
+        givenNoPassphraseIsPresent();
+        givenNoAgentConnectorIsAvailable();
+        whenCreateSshClient();
+        thenIdentityRepositoryIsLocal();
+        thenPreferredAuthenticationIsNotPublicKey();
+    }
+
+    @Test
+    public void testUsePassphrase() throws Exception {
+        givenAPassphraseIsPresent();
+        givenAgentConnectorAvailable();
+        whenCreateSshClient();
+        thenIdentityRepositoryIsLocal();
+    }
+
+    @Test
+    public void testUseSshAgent() throws Exception {
+        givenNoPassphraseIsPresent();
+        givenAgentConnectorAvailable();
+        whenCreateSshClient();
+        thenPreferredAuthenticationIsPublicKey();
+        thenIdentityRepositoryIsRemote();
+    }
+
+    private void givenAgentConnectorAvailable() {
+        connectorAvailable = true;
+    }
+
+    private void givenAPassphraseIsPresent() {
+        when(mockInitialization.getSshPrivateKeyPassphrase()).thenReturn(Optional.of("passphrase"));
+    }
+
+    private void givenNoAgentConnectorIsAvailable() {
+        connectorAvailable = false;
+    }
+
+    private void givenNoPassphraseIsPresent() {
+        when(mockInitialization.getSshPrivateKeyPassphrase()).thenReturn(Optional.<String> absent());
+    }
+
+    private void thenIdentityRepositoryIsLocal() {
+        assertFalse(sshClient.getIdentityRepository() instanceof RemoteIdentityRepository);
+    }
+
+    private void thenIdentityRepositoryIsRemote() {
+        assertTrue(sshClient.getIdentityRepository() instanceof RemoteIdentityRepository);
+    }
+
+    private void thenPreferredAuthenticationIsNotPublicKey() {
+        // if this isn't explicitly set to 'publickey', no passphrase or agent were found
+        assertNotEquals(PUBLIC_KEY, JSch.getConfig(PREFERRED_AUTHENTICATIONS));
+    }
+
+    private void thenPreferredAuthenticationIsPublicKey() {
+        assertEquals(PUBLIC_KEY, JSch.getConfig(PREFERRED_AUTHENTICATIONS));
+    }
+
+    private void whenCreateSshClient() throws Exception {
+        when(mockFS.userHome()).thenReturn(null);
+        sshClient = sessionFactory.createDefaultJSch(mockFS);
+    }
+}


### PR DESCRIPTION
it appears that there can only be a single `IdentityRepository` associated w/ the client, so the logic is if a `passphrase` is found, use that, otherwise check if the agent is available and use that if it is.

as an aside, `ScmProviderGit` would be a lot cleaner if all the log messages got refactored out to a separate helper class, but that's a story for another day.
